### PR TITLE
Fix frame retrieval and output path bug

### DIFF
--- a/modules/capturer.py
+++ b/modules/capturer.py
@@ -13,8 +13,8 @@ def get_video_frame(video_path: str, frame_number: int = 0) -> Any:
     if modules.globals.color_correction:
         capture.set(cv2.CAP_PROP_CONVERT_RGB, 1)
     
-    frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
-    capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))
+    frame_total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    capture.set(cv2.CAP_PROP_POS_FRAMES, min(max(frame_total - 1, 0), frame_number))
     has_frame, frame = capture.read()
 
     if has_frame and modules.globals.color_correction:

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -76,12 +76,11 @@ def get_temp_output_path(target_path: str) -> str:
     return os.path.join(temp_directory_path, TEMP_FILE)
 
 
-def normalize_output_path(source_path: str, target_path: str, output_path: str) -> Any:
-    if source_path and target_path:
+def normalize_output_path(source_path: str, target_path: str, output_path: str | None) -> Any:
+    if source_path and target_path and output_path and os.path.isdir(output_path):
         source_name, _ = os.path.splitext(os.path.basename(source_path))
         target_name, target_extension = os.path.splitext(os.path.basename(target_path))
-        if os.path.isdir(output_path):
-            return os.path.join(output_path, source_name + '-' + target_name + target_extension)
+        return os.path.join(output_path, source_name + '-' + target_name + target_extension)
     return output_path
 
 


### PR DESCRIPTION
## Summary
- adjust video frame selection logic
- handle missing output path gracefully

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68525a8cd3188332bb509f7b762887e0